### PR TITLE
specify invocant explicitly

### DIFF
--- a/lib/Hashids.pm
+++ b/lib/Hashids.pm
@@ -15,7 +15,7 @@ class Hashids {
     has $!seps is ro   = [];
     has $!guards is ro = [];
 
-    method new {
+    method new ($class:) {
         unshift @_, 'salt' if @_ %2 == 1;
         $class->next::method(@_);
     }

--- a/t/lib/SubClassTest.pm
+++ b/t/lib/SubClassTest.pm
@@ -3,7 +3,7 @@ use mop;
 class SubClassTest extends Hashids {
     has $!extra_number is ro = die "'$!extra_number' is required";
 
-    method new {
+    method new ($class:) {
         $class->next::method( salt => 'I want peppers', @_ );
     }
 


### PR DESCRIPTION
We no longer provide `$class` automatically, so it needs to be explicitly specified.
