### PR TITLE
Update to use Math::BigInt

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension Hashids
 
 {{$NEXT}}
 
+1.000002 2015-01-21T23:40:00Z
+
+    - Switched calculations to use Math::BigInt to handle larger integers
+
 1.000001 2014-12-04T06:54:57Z
 
     - Fix issue where some hashes could not be decoded, thanks to

--- a/Changes
+++ b/Changes
@@ -2,10 +2,6 @@ Revision history for Perl extension Hashids
 
 {{$NEXT}}
 
-1.000002 2015-01-21T23:40:00Z
-
-    - Switched calculations to use Math::BigInt to handle larger integers
-
 1.000001 2014-12-04T06:54:57Z
 
     - Fix issue where some hashes could not be decoded, thanks to

--- a/lib/Hashids.pm
+++ b/lib/Hashids.pm
@@ -1,4 +1,4 @@
-package Hashids::BigInt;
+package Hashids;
 
 our $VERSION = "1.000002";
 

--- a/lib/Hashids.pm
+++ b/lib/Hashids.pm
@@ -263,6 +263,7 @@ sub _hash {
     my $hash = '';
     my @alphabet = ref $alphabet eq 'ARRAY' ? @$alphabet : split // => $alphabet;
 
+    $num = _bignum($num);
     do {
         $hash = $alphabet[ _bignum($num)->bmod(_bignum(scalar @alphabet))->numify() ] . $hash;
         $num->bdiv(_bignum(scalar @alphabet) );

--- a/lib/Hashids.pm
+++ b/lib/Hashids.pm
@@ -174,7 +174,7 @@ sub _encode {
 
     if ( @res < $self->minHashLength ) {
         my $guards     = $self->guards;
-        my $guardIndex = _bignum($numHashInt)->badd(_bignum(ord $res[0]))->bmod(__bignum(scalar @$guards));
+        my $guardIndex = _bignum($numHashInt)->badd(_bignum(ord $res[0]))->bmod(_bignum(scalar @$guards));
         my $guard      = $guards->[$guardIndex->numify()];
 
         unshift @res, $guard;

--- a/lib/Hashids.pm
+++ b/lib/Hashids.pm
@@ -232,7 +232,7 @@ sub _decode {
         push @$res => $self->_unhash( $part, \@alphabet );
     }
 
-    return unless $self->encode(@$res) eq $orig;
+    return unless $self->Hashids::encode(@$res) eq $orig;
 
     wantarray ? @$res : @$res == 1 ? $res->[0] : $res;
 }


### PR DESCRIPTION
<code>Hashids.pm</code> now works with arbitrary integer sized on any Perl platform (i.e. 32bit, 64bit, etc) by using <code>Math::BigInt</code>. Also fixes the issue with <code>{en/de}code_hex</code> on 32 bit Perl.