### PR TITLE
Hashids::Util: fix possible infinite loop in to_alphabet()

### DIFF
--- a/lib/Hashids/Util.pm
+++ b/lib/Hashids/Util.pm
@@ -46,7 +46,7 @@ sub to_alphabet {
     $num = bignum($num);
     do {
         $hash = $alphabet[ $num % @alphabet ] . $hash;
-        $num /= @alphabet;
+        $num = int($num / @alphabet);
     } while ( $num != 0 );
 
     $hash;

--- a/t/04_misc.t
+++ b/t/04_misc.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use bignum;
+
+use Test::More;
+use Hashids;
+use Hashids::Util;
+
+plan tests => 2;
+
+ok( bignum::in_effect(), 'bignum pragma is loaded' );
+
+subtest 'should not enter into an infinite loop under bignum pragma' => sub {
+    plan tests => 2;
+
+    my $hashids = Hashids->new;
+    is( $hashids->encode(222), 'LZg', 'encode under bignum pragma' );
+
+    is( Hashids::Util::to_alphabet( 123, 'abcdefghij' ),
+        'bcd', 'internal to_alphabet under bignum pragma' );
+};


### PR DESCRIPTION
When `bignum` pragma is in effect, `to_alphabet()` can get into an
infinite loop due to not reducing its number input down to integer zero.

Fixes #14, thanks @mla!